### PR TITLE
Fix updating OrderCommissionTotalView as part of a create script.

### DIFF
--- a/sql/views/OrderCommissionTotalView.sql
+++ b/sql/views/OrderCommissionTotalView.sql
@@ -1,8 +1,5 @@
--- Drop view first, as Postgres complains about altering the type of
--- commission_total when directly altering Store's OrderCommissionTotalView
-drop OrderCommissionTotalView;
-
 create or replace view OrderCommissionTotalView as
 select orders.id as ordernum,
-	orders.item_total - orders.promotion_total as commission_total
+	cast((orders.item_total - orders.promotion_total) as numeric(11,2))
+		as commission_total
 from Orders;


### PR DESCRIPTION
Cast the returned order total so that column types do not change, and replacing the view works.
