### PR TITLE
Escape entitites for the discount message

### DIFF
--- a/Promo/dataobjects/PromoPromotion.php
+++ b/Promo/dataobjects/PromoPromotion.php
@@ -189,9 +189,11 @@ class PromoPromotion extends SwatDBDataObject
 
 	public function getDiscountMessage(SiteApplication $app)
 	{
-		$message = sprintf(
-			$this->getDiscountMessageText($app),
-			$this->getFormattedDiscount($app)
+		$message = SwatString::minimizeEntities(
+			sprintf(
+				$this->getDiscountMessageText($app),
+				$this->getFormattedDiscount($app)
+			)
 		);
 
 		$rules = $this->getPromotionRulesArray();


### PR DESCRIPTION
We're appending XHTML right below, but not escaping the message text above.

PT Story: https://www.pivotaltracker.com/story/show/82953862
