### PR TITLE
make it easier to subclass the discount message

### DIFF
--- a/Promo/dataobjects/PromoPromotion.php
+++ b/Promo/dataobjects/PromoPromotion.php
@@ -524,7 +524,6 @@ class PromoPromotion extends SwatDBDataObject
 			sprintf(
 				$this->getDiscountMessageText($app),
 				$this->getFormattedDiscount($app)
-				$this->getFormatteduntMessageText($app),
 			)
 		);
 	}

--- a/Promo/dataobjects/PromoPromotion.php
+++ b/Promo/dataobjects/PromoPromotion.php
@@ -198,12 +198,7 @@ class PromoPromotion extends SwatDBDataObject
 	 */
 	public function getDiscountMessage(SiteApplication $app)
 	{
-		$message = SwatString::minimizeEntities(
-			sprintf(
-				$this->getDiscountMessageText($app),
-				$this->getFormattedDiscount($app)
-			)
-		);
+		$message = $this->getFormattedDiscountMessage($app);
 
 		$rules = $this->getPromotionRulesArray();
 		if (count($rules) > 0) {
@@ -513,6 +508,25 @@ class PromoPromotion extends SwatDBDataObject
 		}
 
 		return $valid_dates;
+	}
+
+	// }}}
+	// {{{ protected function getFormattedDiscountMessage()
+
+	/**
+	 * Gets a string with the values for the promotion substituted
+	 *
+	 * @return string
+	 */
+	protected function getFormattedDiscountMessage(SiteApplication $app)
+	{
+		return SwatString::minimizeEntities(
+			sprintf(
+				$this->getDiscountMessageText($app),
+				$this->getFormattedDiscount($app)
+				$this->getFormatteduntMessageText($app),
+			)
+		);
 	}
 
 	// }}}


### PR DESCRIPTION
Before, the text of the message couldn't be added to. It had to follow a strict format. This allows customizing the message text before it's added to the message display (like adding a secondary discount). Technically this was possible by passing in an already formatted message text using `getDiscountMessageText()` but refactoring also make it easier to handle the case where there's 