### PR TITLE
Allow site 14, admin 6, and store 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
 		"php": ">=5.3.0",
 		"ext-mbstring": "*",
 		"pear/text_password": "^1.1.0",
-		"silverorange/admin": "^5.4.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0",
-		"silverorange/store": "^7.2.0 || ^8.1.0",
+		"silverorange/admin": "^5.4.0 || ^6.0.0",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+		"silverorange/store": "^7.2.0 || ^8.1.0 || ^9.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Site 14, admin 6, and store 9 are all tasked with removing
nategosearch. Since cme doesn't use nategosearch or make any
references to the addToSearchQueue method, we are good to allow
these new versions.