### PR TITLE
use new order of implode arguments

### DIFF
--- a/Promo/admin/components/Promotion/GenerateCodes.php
+++ b/Promo/admin/components/Promotion/GenerateCodes.php
@@ -124,7 +124,7 @@ class PromoPromotionGenerateCodes extends AdminDBEdit
 
 		$sql = sprintf(
 			$sql,
-			implode($values_out, ',')
+			implode(',', $values_out)
 		);
 
 		$count = SwatDB::exec($this->app->db, $sql);


### PR DESCRIPTION
https://www.php.net/manual/en/function.implode.php

This was causing the admin tool for generating promo codes to fail.

https://silverorange.slack.com/archives/C0DNY0GHJ/p1669665325220619